### PR TITLE
feat(android): ensure complete process restart for CodePush updates

### DIFF
--- a/android/src/main/kotlin/gabrimatic/info/restart/RestartPlugin.kt
+++ b/android/src/main/kotlin/gabrimatic/info/restart/RestartPlugin.kt
@@ -1,5 +1,4 @@
 package gabrimatic.info.restart
-
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -11,6 +10,9 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import android.os.Process
+import android.os.Handler
+import android.os.Looper
 
 /**
  * `RestartPlugin` class provides a method to restart a Flutter application in Android.
@@ -18,7 +20,7 @@ import io.flutter.plugin.common.MethodChannel.Result
  * It uses the Flutter platform channels to communicate with the Flutter code.
  * Specifically, it uses a `MethodChannel` named 'restart' for this communication.
  *
- * The main functionality is provided by the `onMethodCall` method.
+ * Enhanced to ensure a complete process restart to properly apply Shorebird updates.
  */
 class RestartPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var context: Context
@@ -62,15 +64,52 @@ class RestartPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     /**
-     * Restarts the application.
-     */
+    * Completely restarts the application to ensure updates are properly applied.
+    * 
+    * The restart process follows these steps:
+    * 1. Creates a new launch intent using makeRestartActivityTask() which properly clears the task stack
+    * 2. Starts the new activity instance
+    * 3. Waits a brief moment to ensure the new activity has time to initialize
+    * 4. Terminates the current process completely using Process.killProcess()
+    * 5. Uses Runtime.getRuntime().exit(0) as a backup termination method
+    * 
+    * This implementation specifically addresses issues with Shorebird CodePush and similar
+    * hot update mechanisms that require a complete process restart to apply updates.
+    * 
+    * If the enhanced restart fails for any reason, we fall back to the original implementation
+    * but still force process termination to ensure updates are applied.
+    */
     private fun restartApp() {
         activity?.let { currentActivity ->
-            val intent =
-                currentActivity.packageManager.getLaunchIntentForPackage(currentActivity.packageName)
-            intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            currentActivity.startActivity(intent)
-            currentActivity.finishAffinity()
+            try {
+                // Create a proper restart intent
+                val packageManager = currentActivity.packageManager
+                val intent = packageManager.getLaunchIntentForPackage(currentActivity.packageName)
+                val componentName = intent!!.component
+                val restartIntent = Intent.makeRestartActivityTask(componentName)
+                
+                // Start the new instance
+                currentActivity.startActivity(restartIntent)
+                
+                // Give the new activity time to start
+                Handler(Looper.getMainLooper()).postDelayed({
+                    // Kill the current process completely
+                    Process.killProcess(Process.myPid())
+                    // Force exit as a backup method
+                    Runtime.getRuntime().exit(0)
+                }, 100)
+            } catch (e: Exception) {
+                // Fallback to the previous implementation if anything fails
+                val intent = currentActivity.packageManager.getLaunchIntentForPackage(currentActivity.packageName)
+                intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                currentActivity.startActivity(intent)
+                currentActivity.finishAffinity()
+                
+                // Additionally force process termination
+                Handler(Looper.getMainLooper()).postDelayed({
+                    Process.killProcess(Process.myPid())
+                }, 100)
+            }
         }
     }
 

--- a/android/src/main/kotlin/gabrimatic/info/restart/RestartPlugin.kt
+++ b/android/src/main/kotlin/gabrimatic/info/restart/RestartPlugin.kt
@@ -20,7 +20,7 @@ import android.os.Looper
  * It uses the Flutter platform channels to communicate with the Flutter code.
  * Specifically, it uses a `MethodChannel` named 'restart' for this communication.
  *
- * Enhanced to ensure a complete process restart to properly apply Shorebird updates.
+ * The main functionality is provided by the `onMethodCall` method.
  */
 class RestartPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var context: Context


### PR DESCRIPTION
# Enhanced Android Restart to Support Shorebird CodePush

## Problem
When using Shorebird for CodePush updates on Android, the current restart implementation doesn't fully terminate the app process. This leads to a situation where updates are downloaded but not properly applied until the user manually closes and reopens the app.

## Solution
Enhanced the `RestartPlugin` to perform a complete process termination and restart on Android by:

1. Using Android's `Intent.makeRestartActivityTask()` API to create a proper restart intent that clears the task stack
2. Adding explicit process termination with `Process.killProcess()` and `Runtime.getRuntime().exit(0)`
3. Implementing a short delay to ensure the new activity instance starts before terminating the current process
4. Adding a fallback mechanism to the original implementation if anything fails

## Testing
Tested with Shorebird CodePush updates on multiple Android devices (versions 10-13) and verified that:
- Updates are properly applied immediately after restart
- App state persistence works as expected
- No additional crashes or side effects occur

## Implementation Notes
- This is a backward-compatible change that maintains the same method interface
- The enhancement specifically targets the Android implementation, iOS restart behavior is unchanged
- Added additional error handling to prevent potential crash scenarios
- The implementation handles edge cases like activity context being null