### PR TITLE
Tighten CI path triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,37 @@ name: CI
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - 'doc/**'
-      - 'README.md'
-      - '.github/workflows/docs-pages.yml'
-      - 'test/docs_site_test.dart'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'analysis_options.yaml'
+      - 'pubspec.yaml'
+      - 'lib/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'linux/**'
+      - 'macos/**'
+      - 'windows/**'
+      - 'example/**'
+      - 'test/**'
+      - '!test/docs_site_test.dart'
+      - 'test_apps/**'
   pull_request:
     branches: [master]
-    paths-ignore:
-      - 'doc/**'
-      - 'README.md'
-      - '.github/workflows/docs-pages.yml'
-      - 'test/docs_site_test.dart'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'analysis_options.yaml'
+      - 'pubspec.yaml'
+      - 'lib/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'linux/**'
+      - 'macos/**'
+      - 'windows/**'
+      - 'example/**'
+      - 'test/**'
+      - '!test/docs_site_test.dart'
+      - 'test_apps/**'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/test/docs_site_test.dart
+++ b/test/docs_site_test.dart
@@ -44,9 +44,10 @@ void main() {
     expect(pagesWorkflow, contains('mint export'));
     expect(pagesWorkflow, contains('actions/deploy-pages'));
 
-    expect(ciWorkflow, contains('paths-ignore:'));
-    expect(ciWorkflow, contains('doc/**'));
-    expect(ciWorkflow, contains('.github/workflows/docs-pages.yml'));
-    expect(ciWorkflow, contains('test/docs_site_test.dart'));
+    expect(ciWorkflow, contains('paths:'));
+    expect(ciWorkflow, isNot(contains('doc/**')));
+    expect(ciWorkflow, isNot(contains('README.md')));
+    expect(ciWorkflow, isNot(contains('.github/workflows/docs-pages.yml')));
+    expect(ciWorkflow, contains('!test/docs_site_test.dart'));
   });
 }


### PR DESCRIPTION
## Summary
- switch product CI from broad ignores to explicit code-path triggers
- keep docs-only inputs on the Docs Pages workflow
- update the docs guard test for the stricter trigger contract

## Verification
- flutter test test/docs_site_test.dart
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/ci.yml .github/workflows/docs-pages.yml